### PR TITLE
Feat: add ply_directory input for deterministic, resumable batch output

### DIFF
--- a/nodes/predict.py
+++ b/nodes/predict.py
@@ -160,9 +160,16 @@ class SharpPredict:
                 elif skipped == 4:
                     print(f"[SHARP] Skipping remaining existing files...")
                 all_ply_paths.append(ply_path)
-                # Placeholder camera params for skipped frames
+                # Compute camera params from image dims (consistent with processed frames)
+                skip_h, skip_w = image[i].shape[0], image[i].shape[1]
+                skip_fl = focal_length_mm if focal_length_mm > 0 else 30.0
+                skip_f_px = convert_focallength(skip_w, skip_h, skip_fl)
                 all_extrinsics.append([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
-                all_intrinsics.append(None)
+                all_intrinsics.append([
+                    [skip_f_px, 0, skip_w * 0.5],
+                    [0, skip_f_px, skip_h * 0.5],
+                    [0, 0, 1],
+                ])
                 continue
 
             # Extract single image from batch

--- a/nodes/predict.py
+++ b/nodes/predict.py
@@ -1,5 +1,6 @@
 """SharpPredict node for ComfyUI-Sharp."""
 
+import gc
 import hashlib
 import os
 import time
@@ -150,6 +151,13 @@ class SharpPredict:
             all_intrinsics.append(metadata["intrinsic"])
 
             print(f"[SHARP] Saved: {ply_path} ({metadata['num_gaussians']:,} gaussians)")
+
+            # Clean up intermediate tensors to prevent memory accumulation
+            # during long batch runs (see GitHub issue #7: progressively slower)
+            del gaussians, image_np
+            if device.type == "cuda":
+                torch.cuda.empty_cache()
+            gc.collect()
 
         inference_time = time.time() - inference_start
         print(f"[SHARP] Total inference time: {inference_time:.2f}s ({inference_time/batch_size:.2f}s per image)")


### PR DESCRIPTION
## Summary

- **`ply_directory` input**: New optional string parameter for deterministic output paths (e.g., `vid2vr/my_video/sharp`). Supports subdirectories. When set, uses this exact name instead of appending a timestamp
- **Resume support**: Existing PLY files are automatically skipped, so batch runs survive ComfyUI restarts without re-processing completed frames
- **Proper intrinsics for skipped frames**: Computes camera intrinsics from image dimensions + focal length instead of returning placeholder values

Builds on #16 (batch processing fix).

## Problem

The current timestamp-based output naming (`sharp_{unix_ms}.ply`) means every ComfyUI restart generates a new directory, forcing re-processing of all frames. For long batch jobs (50-100+ frames at ~6s each), losing progress on restart is very costly.

## Changes

### `predict.py`
- Added `ply_directory` optional input (empty string default) with tooltip
- Deterministic directory path: `OUTPUT_DIR/ply_directory/001.ply`, `002.ply`, etc.
- Skip logic: checks `os.path.exists(path) and os.path.getsize(path) > 0`
- Proper intrinsics computation for skipped frames using `convert_focallength()`
- Truncated skip logging (first 3 + "skipping remaining..." + last) to avoid log spam
- Summary logging shows processed vs skipped counts

### Example usage

```
ply_directory: "vid2vr/my_video/sharp"
```
Creates: `output/vid2vr/my_video/sharp/001.ply`, `002.ply`, etc.

On restart, existing PLYs are skipped instantly. Only missing frames are processed.

## Test plan

- [ ] Run batch with `ply_directory` set — verify numbered PLY files created in correct directory
- [ ] Restart ComfyUI and re-run — verify all frames skipped with proper log messages
- [ ] Delete a middle frame, re-run — verify only that frame is re-processed
- [ ] Verify downstream nodes receive correct intrinsics for skipped frames (no division-by-zero)
- [ ] Test without `ply_directory` (empty string) — verify old timestamp behavior preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)